### PR TITLE
Added github repo to dist metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,8 @@
+Revision history for Perl module Hash::Diff
+
+0.008 2015-08-??
+  - Added github repo to Makefile.PL so it will appear in META.*
+
 0.007 2015-08-25
   Better support for undef
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,8 @@ build_requires 'Test::More';
 requires 'Hash::Merge';
 requires 'ok';
 
+repository 'https://github.com/bolav/hash-diff';
+
 auto_install;
 
 WriteAll;


### PR DESCRIPTION
Hi Bjørn,

This adds the github repo into the dist's metadata, so the repo will be linked on the sidebar in MetaCPAN for example, and will also make it a candidate for the [CPAN Pull Request Challenge](http://cpan-prc.org).

Cheers,
Neil
