### PR TITLE
fix: Use of uninitialized value

### DIFF
--- a/lib/Hash/Diff.pm
+++ b/lib/Hash/Diff.pm
@@ -28,7 +28,7 @@ sub left_diff {
                 $rh->{$k} = $h1->{$k}                
             }
         }
-        elsif ((!defined $h2->{$k})||($h1->{$k} ne $h2->{$k})) {
+        elsif ((!defined $h1->{$k})||(!defined $h2->{$k})||($h1->{$k} ne $h2->{$k})) {
             $rh->{$k} = $h1->{$k}
         }
     }


### PR DESCRIPTION
Hi bolav.

many warnings in my products.
try to fix warnings.

regards.

```
./t/91_RT101708_undef_diff.t ..
1..4
ok 1 - Undef 1 ok
ok 2 - Undef 2 ok
ok 3 - Undef 3 ok
Use of uninitialized value in string ne at /Users/nobu/local/src/github.com/nqounet/hash-diff/lib/Hash/Diff.pm line 31.
ok 4 - Undef 4 ok
```
